### PR TITLE
Can't import netflix in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,10 @@
 
 import sys, os
 from setuptools import setup
-import netflix
 
 setup(
     name='python-netflix',
-    version=netflix.__version__,
+    version='0.1.0',
     install_requires=['httplib2', 'oauth2', 'simplejson'],
     author='Mike Helmick',
     author_email='mikehelmick@me.com',


### PR DESCRIPTION
Importing the netflix package at this point throws an error because the
dependencies are needed to even import. At at this point, the
dependencies haven't been parsed or installed.
